### PR TITLE
Write 8 bytes in write_u64_unchecked

### DIFF
--- a/packages/ts-binary/__tests__/writeU64.test.ts
+++ b/packages/ts-binary/__tests__/writeU64.test.ts
@@ -1,0 +1,19 @@
+import { Sink, write_u64, write_u8, read_u8 } from '../src/index';
+
+test('it writes 8 bytes', () => {
+  // Fill with 2s.
+  let sink = Sink(new ArrayBuffer(8));
+  for (let i = 0; i < 8; i++) {
+    sink = write_u8(sink, 2);
+  }
+
+  // Should write out a single 1 and 7 0's, no matter the endianness.
+  sink.pos = 0;
+  sink = write_u64(sink, 1);
+
+  // No byte from the original write should remain.
+  sink.pos = 0;
+  for (let i = 0; i < 8; i++) {
+    expect(read_u8(sink)).toBeLessThan(2);
+  }
+});

--- a/packages/ts-binary/package-lock.json
+++ b/packages/ts-binary/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ts-binary",
-	"version": "0.6.0",
+	"version": "0.8.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ts-binary/src/index.ts
+++ b/packages/ts-binary/src/index.ts
@@ -55,7 +55,16 @@ export const write_u16: Serializer<number> = (sink, val) => {
 
 function write_u64_unchecked(sink: Sink, val: number) {
   const { view, pos, littleEndian } = sink;
+  // Even though we only support writing 4 byte values from JS, it's important
+  // to write 8 bytes in case the buffer is not filled with 0. Otherwise, other
+  // languages that can support 64 bit values (e.g. rust) risk reading garbage
+  // in the other 4 bytes and getting an incorrect value.
+  //
+  // We could require that the Sink buffer be zeroed as part of the API, but
+  // that's easy to forget (and it might be less efficient - it may require the
+  // caller to zero out the entire buffer when that may be mostly unnecessary).
   view.setUint32(littleEndian ? pos : pos + 4, val, littleEndian);
+  view.setUint32(littleEndian ? pos + 4 : pos, 0, littleEndian);
   return (sink.pos += 8), sink;
 }
 


### PR DESCRIPTION
This avoids issues when a buffer is re-used (in that case, the other 4
bytes of the u64 have garbage data from a previous use of the buffer,
and this gives bad values in languages like rust that actually read all
8 bytes.)